### PR TITLE
Implement periodic temperature logging

### DIFF
--- a/esp32/main/config.example.h
+++ b/esp32/main/config.example.h
@@ -41,5 +41,6 @@
 // Intervalles et timeouts
 #define WIFI_CONNECT_TIMEOUT   20     // secondes
 #define WS_SEND_INTERVAL       30000  // millisecondes
+#define LOG_INTERVAL           1000   // intervalle journalisation/affichage (ms)
 
 #endif // CONFIG_H


### PR DESCRIPTION
## Summary
- log temperatures and update the LCD every second
- keep WebSocket transmissions every 30s
- document new configuration constant `LOG_INTERVAL`

## Testing
- `bun run lint`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6884f0ce4648833399ddf3e879c54773