### PR TITLE
Improve ws reconnection and reduce sensor logs

### DIFF
--- a/esp32/main/main.ino
+++ b/esp32/main/main.ino
@@ -50,7 +50,7 @@ void loop() {
     WiFi.reconnect();
     Serial.println("[WIFI] reconnecting...");
   }
-  webSocket.poll();
+  pollWebSocket();
 
   unsigned long now = millis();
 

--- a/esp32/main/network.h
+++ b/esp32/main/network.h
@@ -12,5 +12,6 @@ extern String forcedState; // "ON", "OFF", "AUTO"
 void setupWiFi();
 void setupWebSocket(AppConfig &cfg);
 void sendSensorData(float poolTemp, float outTemp, bool relayState, const AppConfig &cfg);
+void pollWebSocket();
 
 #endif // NETWORK_H

--- a/esp32/main/sensor.cpp
+++ b/esp32/main/sensor.cpp
@@ -18,13 +18,11 @@ void initSensors() {
 float readPoolTemperature() {
   sensorsPool.requestTemperatures();
   float t = sensorsPool.getTempCByIndex(0);
-  Serial.printf("[SENSOR] Pool temp: %0.1f°C\n", t);
   return (t == DEVICE_DISCONNECTED_C) ? -999.0 : t;
 }
 
 float readOutdoorTemperature() {
   sensorsOutdoor.requestTemperatures();
   float t = sensorsOutdoor.getTempCByIndex(0);
-  Serial.printf("[SENSOR] Outdoor temp: %0.1f°C\n", t);
   return (t == DEVICE_DISCONNECTED_C) ? -999.0 : t;
 }


### PR DESCRIPTION
## Summary
- avoid verbose sensor logs for each temperature read
- track websocket connection state
- automatically reconnect the websocket when closed
- use new `pollWebSocket()` in main loop

## Testing
- `bunx turbo lint`
- `bunx turbo type-check`

------
https://chatgpt.com/codex/tasks/task_e_6884f5ff22108333bc23c09f84e5be7f